### PR TITLE
送付先情報入力実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,9 +14,9 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     # 新規登録のストロングパラメータ
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:id, :nickname, :password, :password_confirmation, :email, :family_name, :name, :family_name_kana, :name_kana,:prefecture, :city, :street, :building, :postal_code, :phone, :birth_year, :birth_month, :birth_day])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:id, :nickname, :password, :password_confirmation, :email, :family_name, :name, :family_name_kana, :name_kana, :destination_family_name, :destination_name, :destination_family_name_kana, :destination_name_kana, :prefecture, :city, :street, :building, :postal_code, :phone, :birth_year, :birth_month, :birth_day])
     # 会員情報変更のストロングパラメータ
-    devise_parameter_sanitizer.permit(:account_update, keys: [:id, :nickname, :email, :family_name, :name, :family_name_kana, :name_kana,:prefecture, :city, :street, :building, :postal_code])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:id, :nickname, :email, :family_name, :name, :family_name_kana, :name_kana, :destination_family_name, :destination_name, :destination_family_name_kana, :destination_name_kana, :prefecture, :city, :street, :building, :postal_code])
   end
 
   def production?

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -20,41 +20,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
   end
 
-  # def update
-  #   resource = User.find(params[:id])
-  #   user.update(user_params)
-  #   if resource.save
-  #     if resource.active_for_authentication?
-  #       set_flash_message :notice, :signed_up if is_navigational_format?
-  #       sign_in(resource_name, resource)
-  #       respond_with resource, :location => after_sign_up_path_for(resource)
-  #     else
-  #       set_flash_message :notice, :"signed_up_but_#{resource.inactive_message}" if is_navigational_format?
-  #       expire_session_data_after_sign_in!
-  #       respond_with resource, :location => after_inactive_sign_up_path_for(resource)
-  #     end
-  #   else
-  #     @user = resource
-  #     render :edit
-  #   end
-
-    # product = Product.find(params[:id])
-    # product.update(product_params)
-    # redirect_to action: :show
-  # end
-
   protected
 
-  def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:user, keys: [:id, :nickname, :password, :password_confirmation, :email, :family_name, :name, :family_name_kana, :name_kana,:prefecture, :city, :street, :building, :postal_code, :phone, :birth_year, :birth_month, :birth_day])
-  end
-
-  def configure_edit_params
-    devise_parameter_sanitizer.permit(:user, keys: [:id, :nickname, :password, :password_confirmation, :email, :family_name, :name, :family_name_kana, :name_kana,:prefecture, :city, :street, :building, :postal_code, :phone, :birth_year, :birth_month, :birth_day])
-  end
-
   def user_params
-    params.require(:user).permit(:nickname, :password, :password_confirmation, :email, :family_name, :name, :family_name_kana, :name_kana,:prefecture, :city, :street, :building, :postal_code, :phone, :birth_year, :birth_month, :birth_day)
+    params.require(:user).permit(:nickname, :password, :password_confirmation, :email, :family_name, :name, :family_name_kana, :name_kana, :destination_family_name, :destination_name, :destination_family_name_kana, :destination_name_kana, :prefecture, :city, :street, :building, :postal_code, :phone, :birth_year, :birth_month, :birth_day)
   end
 
   def update_resource(resource, params)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,21 +6,25 @@ class User < ApplicationRecord
   
   has_one :credit_card
 
-  validates :nickname,         presence: true, length: { in: 1..20 }, uniqueness: true
-  validates :email,            presence: true, uniqueness: true
-  validates :password,         presence: true, length: { in: 7..128 }, confirmation: true, on: :create
-  validates :family_name,      presence: true
-  validates :name,             presence: true
-  validates :family_name_kana, presence: true, format: { with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/, message: "全角カタカナのみで入力して下さい" }
-  validates :name_kana,        presence: true, format: { with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/, message: "全角カタカナのみで入力して下さい" }
-  validates :prefecture,       presence: true, numericality: { only_integer: true }
-  validates :city,             presence: true
-  validates :street,           presence: true
-  validates :postal_code,      presence: true, numericality: { only_integer: true }, length: { in: 7..7 }
-  validates :phone,            presence: true, numericality: { only_integer: true }, length: { in: 10..11 }, uniqueness: true
-  validates :birth_year,       presence: true, numericality: { only_integer: true }
-  validates :birth_month,      presence: true, numericality: { only_integer: true }
-  validates :birth_day,        presence: true, numericality: { only_integer: true }
+  validates :nickname,                     presence: true, length: { in: 1..20 }, uniqueness: true
+  validates :email,                        presence: true, uniqueness: true
+  validates :password,                     presence: true, length: { in: 7..128 }, confirmation: true, on: :create
+  validates :family_name,                  presence: true
+  validates :name,                         presence: true
+  validates :family_name_kana,             presence: true, format: { with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/, message: "全角カタカナのみで入力して下さい" }
+  validates :name_kana,                    presence: true, format: { with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/, message: "全角カタカナのみで入力して下さい" }
+  validates :destination_family_name,      presence: true
+  validates :destination_name,             presence: true
+  validates :destination_family_name_kana, presence: true, format: { with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/, message: "全角カタカナのみで入力して下さい" }
+  validates :destination_name_kana,        presence: true, format: { with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/, message: "全角カタカナのみで入力して下さい" }
+  validates :prefecture,                   presence: true, numericality: { only_integer: true }
+  validates :city,                         presence: true
+  validates :street,                       presence: true
+  validates :postal_code,                  presence: true, numericality: { only_integer: true }, length: { in: 7..7 }
+  validates :phone,                        presence: true, numericality: { only_integer: true }, length: { in: 10..11 }, uniqueness: true
+  validates :birth_year,                   presence: true, numericality: { only_integer: true }
+  validates :birth_month,                  presence: true, numericality: { only_integer: true }
+  validates :birth_day,                    presence: true, numericality: { only_integer: true }
 
 
   def update_without_current_password(params, *options)

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,7 +1,7 @@
 .single-container
   %main.single-main
     %section.l-single-container
-      %h2.l-single-head 会員情報変更
+      %h2.l-single-head 登録情報変更
       = form_for(resource, url: registration_path(resource_name), html: {method: :patch, id: "new_user_form",class: 'l-single-inner'}) do |f|
         = render "devise/shared/error_messages", resource: resource
         .l-single-content
@@ -14,17 +14,30 @@
             %span.form-require 必須
             = f.email_field :email, autocomplete: "email", placeholder: "PC・携帯どちらでも可",required: "required", pattern: "/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i", class: "input-default"
           .form-group
-            = f.label :お名前（全角）
+            = f.label :本名（全角）
             %span.form-require 必須
             %br/
             = f.text_field :family_name, placeholder: "例) 振間",required: "required", class: "input-default__name"
             = f.text_field :name, placeholder: "例) 太郎",required: "required", class: "input-default__name"
           .form-group
-            = f.label :お名前カナ（全角）
+            = f.label :本名カナ（全角）
             %span.form-require 必須
             %br/
             = f.text_field :family_name_kana, placeholder: "例) フリマ",required: "required", pattern: "^[ァ-ンヴー]*$", title: "カタカナで入力してください。", class: "input-default__name"
             = f.text_field :name_kana, placeholder: "例) タロウ",required: "required", pattern: "^[ァ-ンヴー]*$", title: "カタカナで入力してください。", class: "input-default__name"
+          %h2.l-single-head 送付先情報変更
+          .form-group
+            = f.label :送付先宛名（全角）
+            %span.form-require 必須
+            %br/
+            = f.text_field :destination_family_name, placeholder: "例) 振間",required: "required", class: "input-default__name"
+            = f.text_field :destination_name, placeholder: "例) 太郎",required: "required", class: "input-default__name"
+          .form-group
+            = f.label :送付先宛名カナ（全角）
+            %span.form-require 必須
+            %br/
+            = f.text_field :destination_family_name_kana, placeholder: "例) フリマ",required: "required", pattern: "^[ァ-ンヴー]*$", title: "カタカナで入力してください。", class: "input-default__name"
+            = f.text_field :destination_name_kana, placeholder: "例) タロウ",required: "required", pattern: "^[ァ-ンヴー]*$", title: "カタカナで入力してください。", class: "input-default__name"
           .form-group
             = f.label :郵便番号（ハイフン除く）
             %span.form-require 必須
@@ -48,5 +61,5 @@
           .form-group
         
         .l-single-content
-          %button.btn-default.btn-next{type: "submit"} 修正する
+          %button.btn-default.btn-next{type: "submit"} 変更する
   = render "layouts/user_footer"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -41,13 +41,13 @@
             %p.l-single-text
               安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
           .form-group
-            = f.label :お名前（全角）
+            = f.label :本名（全角）
             %span.form-require 必須
             %br/
             = f.text_field :family_name, placeholder: "例) 振間",required: "required", class: "input-default__name"
             = f.text_field :name, placeholder: "例) 太郎",required: "required", class: "input-default__name"
           .form-group
-            = f.label :お名前カナ（全角）
+            = f.label :本名カナ（全角）
             %span.form-require 必須
             %br/
             = f.text_field :family_name_kana, placeholder: "例) フリマ",required: "required", pattern: "^[ァ-ンヴー]*$", title: "カタカナで入力してください。", class: "input-default__name"
@@ -66,6 +66,27 @@
               .select-wrap
                 = f.select :birth_day, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31], {include_blank: "--"}, {required: "required", class: "select-default"}
               %span.horizonal-info 日
+          .form-group
+            = f.label :電話番号（ハイフン除く）
+            %span.form-require 必須
+            = f.text_field :phone,required: "required", placeholder: "例) 09012345678", minlength: "10", maxlength: "11", pattern: "^[0-9]+$", title: "ハイフンを除き、数字のみ", class: 'input-default'
+            %p.form-info
+              ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
+
+
+          %h2.l-single-head 送付先情報入力
+          .form-group
+            = f.label :送付先宛名（全角）
+            %span.form-require 必須
+            %br/
+            = f.text_field :destination_family_name, placeholder: "例) 振間",required: "required", class: "input-default__name"
+            = f.text_field :destination_name, placeholder: "例) 太郎",required: "required", class: "input-default__name"
+          .form-group
+            = f.label :送付先宛名カナ（全角）
+            %span.form-require 必須
+            %br/
+            = f.text_field :destination_family_name_kana, placeholder: "例) フリマ",required: "required", pattern: "^[ァ-ンヴー]*$", title: "カタカナで入力してください。", class: "input-default__name"
+            = f.text_field :destination_  name_kana, placeholder: "例) タロウ",required: "required", pattern: "^[ァ-ンヴー]*$", title: "カタカナで入力してください。", class: "input-default__name"
           .form-group
             = f.label :郵便番号（ハイフン除く）
             %span.form-require 必須
@@ -86,59 +107,6 @@
             = f.label :建物名
             %span.form-optional 任意
             = f.text_field :building, placeholder: "例) アジアビル ９Ｆ", class: 'input-default'
-          .form-group
-            = f.label :電話番号（ハイフン除く）
-            %span.form-require 必須
-            = f.text_field :phone,required: "required", placeholder: "例) 09012345678", minlength: "10", maxlength: "11", pattern: "^[0-9]+$", title: "ハイフンを除き、数字のみ", class: 'input-default'
-            %p.form-info
-              ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
-          
-        -# カード登録のタイミングは、購入機能実装時に変更（一時的に下記コードをコメントアウトし保存中）
-
-          -# .card-form
-          -#   = f.label :カード番号, class: "card-form__title"
-          -#   %span.form-require.card-form__label 必須
-          -#   = f.number_field :number, id: "payment_card_no",required: "required", class: "card-form__input", maxlength: "17", placeholder: "半角数字のみ"
-          -#   %ul#card-no-error-wrapper.has-error-text
-          -#   %ul.card-list
-          -#     %li
-          -#       = image_tag("//www-mercari-jp.akamaized.net/assets/img/card/visa.svg?2845599746",alt: "",class: "card-list__image--visa")
-          -#     %li
-          -#       = image_tag("//www-mercari-jp.akamaized.net/assets/img/card/master-card.svg?2845599746",alt: "",class: "card-list__image--master")
-          -#     %li
-          -#       = image_tag("//www-mercari-jp.akamaized.net/assets/img/card/saison-card.svg?2845599746",alt: "",class: "card-list__image--saison")
-          -#     %li
-          -#       = image_tag("//www-mercari-jp.akamaized.net/assets/img/card/jcb.svg?2845599746",alt: "",class: "card-list__image--jcb-club-dis")
-          -#     %li
-          -#       = image_tag("//www-mercari-jp.akamaized.net/assets/img/card/american_express.svg?2845599746",alt: "",class: "card-list__image--american-express")
-          -#     %li
-          -#       = image_tag("//www-mercari-jp.akamaized.net/assets/img/card/dinersclub.svg?2845599746",alt: "",class: "card-list__image--jcb-club-dis")
-          -#     %li
-          -#       = image_tag("//www-mercari-jp.akamaized.net/assets/img/card/discover.svg?2845599746",alt: "" ,class: "card-list__image--jcb-club-dis")
-
-          -# .card-form
-          -#   = f.label :有効期限, class: "card-form__title"
-          -#   %span.form-require.card-form__label 必須
-          -#   %br
-          -#   .horizonal-wrap
-          -#     = f.collection_select :exp_month, CardMonth.all,:id,:name,{} ,{class: "select-default exp_month",id: "exp_month"}
-          -#     %span.horizonal-info 月
-          -#     = f.collection_select :exp_year, CardYear.all,:value,:name, {} ,{ class: "select-default",id: "exp_year"}
-          -#     %span.horizonal-info 年
-
-          -# .card-form
-          -#   = f.label :セキュリティコード, class: "card-form__title"
-          -#   %span.form-require.card-form__label 必須
-          -#   = f.number_field :cvc,required: "required", placeholder: "カード背面4桁もしくは3桁の番号", id: "payment_card_security_code", class: "card-form__input"
-
-          -#   %ul#security-code-error-wrapper.has-error-text
-          -#   .card-seqcode
-          -#     .card-seqcode__text
-          -#       %span.form-question> ?
-          -#       カード裏面の番号とは？
-          -#     .card-seqcode__info
-          -#       カードの裏面をご参照ください。
-
         .l-single-content
           .form-group
             %p.l-single-text.text-center

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -72,8 +72,6 @@
             = f.text_field :phone,required: "required", placeholder: "例) 09012345678", minlength: "10", maxlength: "11", pattern: "^[0-9]+$", title: "ハイフンを除き、数字のみ", class: 'input-default'
             %p.form-info
               ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
-
-
           %h2.l-single-head 送付先情報入力
           .form-group
             = f.label :送付先宛名（全角）
@@ -86,7 +84,7 @@
             %span.form-require 必須
             %br/
             = f.text_field :destination_family_name_kana, placeholder: "例) フリマ",required: "required", pattern: "^[ァ-ンヴー]*$", title: "カタカナで入力してください。", class: "input-default__name"
-            = f.text_field :destination_  name_kana, placeholder: "例) タロウ",required: "required", pattern: "^[ァ-ンヴー]*$", title: "カタカナで入力してください。", class: "input-default__name"
+            = f.text_field :destination_name_kana, placeholder: "例) タロウ",required: "required", pattern: "^[ァ-ンヴー]*$", title: "カタカナで入力してください。", class: "input-default__name"
           .form-group
             = f.label :郵便番号（ハイフン除く）
             %span.form-require 必須

--- a/app/views/devise/registrations/update.html.haml
+++ b/app/views/devise/registrations/update.html.haml
@@ -10,12 +10,12 @@
   // 情報変更完了画面
   %main.single-main
     %section.l-single-container
-      %h2.l-single-head 会員情報変更完了
+      %h2.l-single-head 登録情報変更完了
       .l-single-inner
         .l-single-content
           .form-group
             %p.form-info-text
-              会員情報変更が完了しました。
+              登録情報変更が完了しました。
 
           .btn-default.btn-next
             = link_to 'マイページに戻る', users_show_path

--- a/app/views/products/buy.html.haml
+++ b/app/views/products/buy.html.haml
@@ -45,6 +45,7 @@
               = "〒 #{@user.postal_code.to_s.insert(3, "-")}"
               %br
               = "#{@prefecture.name} #{@user.city} #{@user.street} #{@user.building}"
+              = "#{@user.destination_family_name} #{@user.destination_name}"
           - if @credit_card.present?
             = link_to "購入する", done_product_purchase_path(@product.id), class:"buy-button check"
           - else

--- a/app/views/users/_sidebar.html.haml
+++ b/app/views/users/_sidebar.html.haml
@@ -65,7 +65,7 @@
       =icon("fas", "chevron-right")
     %li#list16.sideLink
       = link_to edit_user_registration_path(current_user) do
-        会員情報変更
+        登録情報変更
       =icon("fas", "chevron-right")
     %li#list17
       = link_to "#content17" do

--- a/db/migrate/20200305100737_devise_create_users.rb
+++ b/db/migrate/20200305100737_devise_create_users.rb
@@ -10,6 +10,10 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.string :name, null: false
       t.string :family_name_kana, null: false
       t.string :name_kana, null: false
+      t.string :destination_family_name, null: false
+      t.string :destination_name, null: false
+      t.string :destination_family_name_kana, null: false
+      t.string :destination_name_kana, null: false
       t.integer :prefecture, null: false
       t.string :city, null: false
       t.string :street, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -109,6 +109,10 @@ ActiveRecord::Schema.define(version: 2020_03_19_120930) do
     t.string "name", null: false
     t.string "family_name_kana", null: false
     t.string "name_kana", null: false
+    t.string "destination_family_name", null: false
+    t.string "destination_name", null: false
+    t.string "destination_family_name_kana", null: false
+    t.string "destination_name_kana", null: false
     t.integer "prefecture", null: false
     t.string "city", null: false
     t.string "street", null: false


### PR DESCRIPTION
# what
本人確認情報の他に、送付先の名前を登録できるように実装しました。

# why
ユーザー側の事情で登録者の名前と送付先の宛名が異なる場合があり、そうしたケースにも対応できるようにすることでユーザー満足度の向上を図るため。